### PR TITLE
Fix: Remove dependency on `material-icons-extended`.

### DIFF
--- a/compose-settings-ui/build.gradle.kts
+++ b/compose-settings-ui/build.gradle.kts
@@ -59,6 +59,5 @@ dependencies {
 
   implementation("androidx.compose.ui:ui:1.0.3")
   implementation("androidx.compose.material:material:1.0.3")
-  implementation("androidx.compose.material:material-icons-extended:1.0.3")
   implementation("androidx.compose.ui:ui-tooling:1.0.3")
 }


### PR DESCRIPTION
This PR removes the `compose-settings-ui` dependency on `material-icons-extended`. The extended icons are still a dependency of the `app` sample (since it is not published). Fixes #17.