### PR TITLE
Completes #100 & misc.

### DIFF
--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -41,8 +41,11 @@ fun SettingsListDropdown(
   }
 
   Surface {
+    var isDropdownExpanded by remember { mutableStateOf(false) }
+
     Row(
-      modifier = modifier.fillMaxWidth(),
+      modifier = modifier.fillMaxWidth()
+        .clickable(enabled = enabled) { isDropdownExpanded = true },
       verticalAlignment = Alignment.CenterVertically
     ) {
       SettingsTileScaffold(
@@ -51,20 +54,12 @@ fun SettingsListDropdown(
         subtitle = subtitle,
         icon = icon,
         action = {
-          var isDropdownExpanded by remember {
-            mutableStateOf(false)
-          }
-
           WrapContentColor(enabled = enabled) {
             Column(
               modifier = Modifier.padding(end = 8.dp)
             ) {
               Row(
-                modifier = Modifier
-                  .clickable(
-                    enabled = enabled,
-                  ) { isDropdownExpanded = true }
-                  .padding(vertical = 5.dp),
+                modifier = Modifier.padding(vertical = 5.dp),
                 verticalAlignment = Alignment.CenterVertically
               ) {
                 Text(text = items[state.value])

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -43,8 +43,11 @@ fun SettingsListDropdown(
 
   Surface {
     WrapContentColor(enabled = enabled) {
+      var isDropdownExpanded by remember { mutableStateOf(false) }
+
       Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth()
+          .clickable(enabled = enabled) { isDropdownExpanded = true },
         verticalAlignment = Alignment.CenterVertically
       ) {
         Row(
@@ -58,16 +61,11 @@ fun SettingsListDropdown(
           )
         }
 
-        var isDropdownExpanded by remember {
-          mutableStateOf(false)
-        }
-
         Column(
           modifier = Modifier.padding(end = 8.dp)
         ) {
           Row(
             modifier = Modifier
-              .clickable(enabled = enabled) { isDropdownExpanded = true }
               .padding(vertical = 5.dp),
             verticalAlignment = Alignment.CenterVertically
           ) {

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsMenuLink.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsMenuLink.kt
@@ -46,7 +46,10 @@ fun SettingsMenuLink(
         Row(
           modifier = Modifier
             .weight(1f)
-            .clickable(onClick = onClick),
+            .clickable(
+              enabled = enabled,
+              onClick = onClick
+            ),
           verticalAlignment = Alignment.CenterVertically,
         ) {
           SettingsTileIcon(icon = icon)


### PR DESCRIPTION
1. Added `enabled` flag to `SettingsMenuLink`.
2. Added same `tile-wide` click behaviour to `SettingsListDropdown` as other list tile components.

This should completely close #100 now.