### PR TITLE
Enhancements & fixes.

### DIFF
--- a/app/src/main/java/com/alorma/compose/settings/example/ui/screens/ListScreen.kt
+++ b/app/src/main/java/com/alorma/compose/settings/example/ui/screens/ListScreen.kt
@@ -1,5 +1,6 @@
 package com.alorma.compose.settings.example.ui.screens
 
+import android.widget.Toast
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -7,6 +8,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.alorma.compose.settings.example.demo.AppScaffold
@@ -23,6 +25,7 @@ fun ListScreen(
   navController: NavController = rememberNavController(),
 ) {
 
+  val localContext = LocalContext.current
   val enabledState = rememberBooleanSettingState(true)
 
   AppScaffold(
@@ -48,6 +51,9 @@ fun ListScreen(
           )
         }
       },
+      onItemSelected = { _, text ->
+        Toast.makeText(localContext, "Selected Item: $text", Toast.LENGTH_SHORT).show()
+      }
     )
     Divider()
     val multiChoiceState =
@@ -70,7 +76,13 @@ fun ListScreen(
           )
         }
       },
-      confirmButton = "Select"
+      confirmButton = "Select",
+      onItemsSelected = { items ->
+        Toast.makeText(
+          localContext,
+          "Selected Item: ${items.joinToString(", ")}", Toast.LENGTH_SHORT
+        ).show()
+      }
     )
     Divider()
     val dropdownChoiceState =
@@ -81,6 +93,9 @@ fun ListScreen(
       title = { Text(text = "Dropdown choice") },
       subtitle = { Text(text = "Select a single fruit") },
       items = listOf("Banana", "Kiwi", "Pineapple"),
+      onItemSelected = { _, text ->
+        Toast.makeText(localContext, "Selected Item: $text", Toast.LENGTH_SHORT).show()
+      }
     )
   }
 }

--- a/app_m3/src/main/java/com/alorma/compose/settings/example/ui/screens/ListScreen.kt
+++ b/app_m3/src/main/java/com/alorma/compose/settings/example/ui/screens/ListScreen.kt
@@ -1,5 +1,6 @@
 package com.alorma.compose.settings.example.ui.screens
 
+import android.widget.Toast
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.Divider
@@ -7,6 +8,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.alorma.compose.settings.example.demo.AppScaffold
@@ -23,6 +25,7 @@ fun ListScreen(
   navController: NavController = rememberNavController(),
 ) {
 
+  val localContext = LocalContext.current
   val enabledState = rememberBooleanSettingState(true)
 
   AppScaffold(
@@ -48,6 +51,9 @@ fun ListScreen(
           )
         }
       },
+      onItemSelected = { _, text ->
+        Toast.makeText(localContext, "Selected Item: $text", Toast.LENGTH_SHORT).show()
+      }
     )
     Divider()
     val multiChoiceState =
@@ -70,7 +76,13 @@ fun ListScreen(
           )
         }
       },
-      confirmButton = "Select"
+      confirmButton = "Select",
+      onItemsSelected = { items ->
+        Toast.makeText(
+          localContext,
+          "Selected Item: ${items.joinToString(", ")}", Toast.LENGTH_SHORT
+        ).show()
+      }
     )
     Divider()
     val dropdownChoiceState =
@@ -81,6 +93,9 @@ fun ListScreen(
       title = { Text(text = "Dropdown choice") },
       subtitle = { Text(text = "Select a single fruit") },
       items = listOf("Banana", "Kiwi", "Pineapple"),
+      onItemSelected = { _, text ->
+        Toast.makeText(localContext, "Selected Item: $text", Toast.LENGTH_SHORT).show()
+      }
     )
   }
 }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
@@ -73,9 +73,9 @@ fun SettingsList(
   if (!showDialog) return
 
   val coroutineScope = rememberCoroutineScope()
-  val onSelected: (Int) -> Unit = { selectedIndex ->
+  val onSelected: (Int, Boolean) -> Unit = { selectedIndex, updateState ->
     coroutineScope.launch {
-      state.value = selectedIndex
+      if (updateState) state.value = selectedIndex
       delay(closeDialogDelay)
       showDialog = false
     }
@@ -104,7 +104,7 @@ fun SettingsList(
                 role = Role.RadioButton,
                 selected = isSelected,
                 onClick = {
-                  if (!isSelected) onSelected(index)
+                  onSelected(index, !isSelected)
                   onItemSelected?.invoke(index, items[index])
                 }
               ),

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
@@ -45,6 +45,7 @@ fun SettingsList(
   subtitle: (@Composable () -> Unit)? = null,
   closeDialogDelay: Long = 200,
   action: (@Composable (Boolean) -> Unit)? = null,
+  onItemSelected: ((Int, String) -> Unit)? = null
 ) {
 
   if (state.value >= items.size) {
@@ -102,7 +103,10 @@ fun SettingsList(
               .selectable(
                 role = Role.RadioButton,
                 selected = isSelected,
-                onClick = { if (!isSelected) onSelected(index) }
+                onClick = {
+                  if (!isSelected) onSelected(index)
+                  onItemSelected?.invoke(index, items[index])
+                }
               ),
             verticalAlignment = Alignment.CenterVertically
           ) {

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -41,8 +41,11 @@ fun SettingsListDropdown(
   }
 
   Surface {
+    var isDropdownExpanded by remember { mutableStateOf(false) }
+
     Row(
-      modifier = modifier.fillMaxWidth(),
+      modifier = modifier.fillMaxWidth()
+        .clickable(enabled = enabled) { isDropdownExpanded = true },
       verticalAlignment = Alignment.CenterVertically
     ) {
       SettingsTileScaffold(
@@ -51,20 +54,12 @@ fun SettingsListDropdown(
         subtitle = subtitle,
         icon = icon,
         action = {
-          var isDropdownExpanded by remember {
-            mutableStateOf(false)
-          }
-
           WrapContentColor(enabled = enabled) {
             Column(
               modifier = Modifier.padding(end = 8.dp)
             ) {
               Row(
-                modifier = Modifier
-                  .clickable(
-                    enabled = enabled,
-                  ) { isDropdownExpanded = true }
-                  .padding(vertical = 5.dp),
+                modifier = Modifier.padding(vertical = 5.dp),
                 verticalAlignment = Alignment.CenterVertically
               ) {
                 Text(text = items[state.value])

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -34,6 +34,7 @@ fun SettingsListDropdown(
   items: List<String>,
   icon: (@Composable () -> Unit)? = null,
   subtitle: (@Composable () -> Unit)? = null,
+  onItemSelected: ((Int, String) -> Unit)? = null,
   menuItem: (@Composable (index: Int, text: String) -> Unit)? = null,
 ) {
   if (state.value > items.size) {
@@ -86,6 +87,7 @@ fun SettingsListDropdown(
                     onClick = {
                       state.value = index
                       isDropdownExpanded = false
+                      onItemSelected?.invoke(index, text)
                     }
                   )
                 }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListMultiSelect.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListMultiSelect.kt
@@ -36,6 +36,7 @@ fun SettingsListMultiSelect(
   confirmButton: String,
   useSelectedValuesAsSubtitle: Boolean = true,
   subtitle: @Composable (() -> Unit)? = null,
+  onItemsSelected: ((List<String>) -> Unit)? = null,
   action: @Composable ((Boolean) -> Unit)? = null,
 ) {
 
@@ -119,7 +120,10 @@ fun SettingsListMultiSelect(
     onDismissRequest = { showDialog = false },
     confirmButton = {
       TextButton(
-        onClick = { showDialog = false },
+        onClick = {
+          showDialog = false
+          onItemsSelected?.invoke(state.value.map { index -> items[index] })
+        },
       ) {
         Text(text = confirmButton)
       }

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsCheckbox.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsCheckbox.kt
@@ -1,7 +1,9 @@
 package com.alorma.compose.settings.ui
 
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Icon
@@ -15,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.alorma.compose.settings.storage.base.SettingValueState
 import com.alorma.compose.settings.storage.base.getValue
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
@@ -54,11 +57,13 @@ fun SettingsCheckbox(
       WrapContentColor(enabled = enabled) {
         SettingsTileIcon(icon = icon)
         SettingsTileTexts(title = title, subtitle = subtitle)
+        Spacer(modifier = Modifier.weight(1f))
         SettingsTileAction {
           Checkbox(
             enabled = enabled,
             checked = storageValue,
-            onCheckedChange = update
+            onCheckedChange = update,
+            modifier = Modifier.padding(end = 8.dp)
           )
         }
       }

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
@@ -41,6 +41,7 @@ fun SettingsList(
   subtitle: (@Composable () -> Unit)? = null,
   closeDialogDelay: Long = 200,
   action: (@Composable (Boolean) -> Unit)? = null,
+  onItemSelected: ((Int, String) -> Unit)? = null
 ) {
 
   if (state.value >= items.size) {
@@ -88,7 +89,10 @@ fun SettingsList(
                 .selectable(
                     role = Role.RadioButton,
                     selected = isSelected,
-                    onClick = { if (!isSelected) onSelected(index) }
+                    onClick = {
+                      if (!isSelected) onSelected(index)
+                      onItemSelected?.invoke(index, items[index])
+                    }
                 )
                 .padding(
                     start = 33.dp,

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsList.kt
@@ -67,9 +67,9 @@ fun SettingsList(
   if (!showDialog) return
 
   val coroutineScope = rememberCoroutineScope()
-  val onSelected: (Int) -> Unit = { selectedIndex ->
+  val onSelected: (Int, Boolean) -> Unit = { selectedIndex, updateState ->
     coroutineScope.launch {
-      state.value = selectedIndex
+      if (updateState) state.value = selectedIndex
       delay(closeDialogDelay)
       showDialog = false
     }
@@ -90,7 +90,7 @@ fun SettingsList(
                     role = Role.RadioButton,
                     selected = isSelected,
                     onClick = {
-                      if (!isSelected) onSelected(index)
+                      onSelected(index, !isSelected)
                       onItemSelected?.invoke(index, items[index])
                     }
                 )
@@ -104,7 +104,7 @@ fun SettingsList(
           ) {
             RadioButton(
               selected = isSelected,
-              onClick = { if (!isSelected) onSelected(index) }
+              onClick = null
             )
             Text(
               text = item,

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -43,8 +43,11 @@ fun SettingsListDropdown(
 
   Surface {
     WrapContentColor(enabled = enabled) {
+      var isDropdownExpanded by remember { mutableStateOf(false) }
+
       Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth()
+          .clickable(enabled = enabled) { isDropdownExpanded = true },
         verticalAlignment = Alignment.CenterVertically
       ) {
         Row(
@@ -58,16 +61,11 @@ fun SettingsListDropdown(
           )
         }
 
-        var isDropdownExpanded by remember {
-          mutableStateOf(false)
-        }
-
         Column(
           modifier = Modifier.padding(end = 8.dp)
         ) {
           Row(
             modifier = Modifier
-              .clickable(enabled = enabled) { isDropdownExpanded = true }
               .padding(vertical = 5.dp),
             verticalAlignment = Alignment.CenterVertically
           ) {

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -35,6 +35,7 @@ fun SettingsListDropdown(
   items: List<String>,
   icon: (@Composable () -> Unit)? = null,
   subtitle: (@Composable () -> Unit)? = null,
+  onItemSelected: ((Int, String) -> Unit)? = null,
   menuItem: (@Composable (index: Int, text: String) -> Unit)? = null,
 ) {
   if (state.value > items.size) {
@@ -86,6 +87,7 @@ fun SettingsListDropdown(
                 onClick = {
                   state.value = index
                   isDropdownExpanded = false
+                  onItemSelected?.invoke(index, text)
                 }
               ) {
                 if (menuItem != null) {

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListMultiSelect.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListMultiSelect.kt
@@ -31,11 +31,12 @@ fun SettingsListMultiSelect(
   state: SettingValueState<Set<Int>> = rememberIntSetSettingState(),
   title: @Composable () -> Unit,
   items: List<String>,
-  icon: @Composable() (() -> Unit)? = null,
+  icon: @Composable (() -> Unit)? = null,
   confirmButton: String,
   useSelectedValuesAsSubtitle: Boolean = true,
-  subtitle: @Composable() (() -> Unit)? = null,
-  action: @Composable() ((Boolean) -> Unit)? = null,
+  subtitle: @Composable (() -> Unit)? = null,
+  onItemsSelected: ((List<String>) -> Unit)? = null,
+  action: @Composable ((Boolean) -> Unit)? = null,
 ) {
 
   if (state.value.any { index -> index >= items.size }) {
@@ -123,7 +124,10 @@ fun SettingsListMultiSelect(
     onDismissRequest = { showDialog = false },
     confirmButton = {
       TextButton(
-        onClick = { showDialog = false },
+        onClick = {
+          showDialog = false
+          onItemsSelected?.invoke(state.value.map { index -> items[index] })
+        },
       ) {
         ProvideTextStyle(
           value = MaterialTheme.typography.button.copy(fontFeatureSettings = "c2sc, smcp")

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsMenuLink.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsMenuLink.kt
@@ -46,7 +46,10 @@ fun SettingsMenuLink(
         Row(
           modifier = Modifier
             .weight(1f)
-            .clickable(onClick = onClick),
+            .clickable(
+              enabled = enabled,
+              onClick = onClick
+            ),
           verticalAlignment = Alignment.CenterVertically,
         ) {
           SettingsTileIcon(icon = icon)

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
@@ -1,7 +1,9 @@
 package com.alorma.compose.settings.ui
 
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -15,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.alorma.compose.settings.storage.base.SettingValueState
 import com.alorma.compose.settings.storage.base.getValue
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
@@ -54,10 +57,12 @@ fun SettingsSwitch(
       WrapContentColor(enabled = enabled) {
         SettingsTileIcon(icon = icon)
         SettingsTileTexts(title = title, subtitle = subtitle)
+        Spacer(modifier = Modifier.weight(1f))
         SettingsTileAction {
           Switch(
             checked = storageValue,
-            onCheckedChange = update
+            onCheckedChange = update,
+            Modifier.padding(end = 8.dp)
           )
         }
       }

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileIcon.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileIcon.kt
@@ -1,6 +1,8 @@
 package com.alorma.compose.settings.ui.internal
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -17,13 +19,17 @@ internal fun SettingsTileIcon(
   modifier: Modifier = Modifier,
   icon: @Composable (() -> Unit)? = null,
 ) {
-  Box(
+
+  if (icon == null) {
+    Spacer(modifier = modifier
+      .padding(end = 16.dp)
+      .size(width = 16.dp, height = 64.dp))
+  }
+  else Box(
     modifier = modifier.size(64.dp),
     contentAlignment = Alignment.Center,
   ) {
-    if (icon != null) {
       icon()
-    }
   }
 }
 


### PR DESCRIPTION
This PR includes following enhancements, fixes:
1. `OnItemSelected` & `OnItemsSelected` for both m2 & m3 variants via 63e5670 & 8e24215.
Current implementation does not allow the developer to know which items were selected without explicitly using the `SharedPreference` or observing the `remember*SettingState` somewhere in the composable.

2. The `SettingsTileIcon` leaves an empty space if the `icon` is null which is not correct as per the native preferences & also the m3's `SettingsTileScaffold` implementation which uses a `ListItem` & therefore has an `.padding(end = 16.dp)` for the `leading` content.

3. The same commit as pointer **2** includes fixes to Checkbox & Switch layout positions.
These widgets should be to the far right/end of the tile in `m2`.
The `m3` has correct implementation due to `ListItem.trailingContent`.

4. Currently if the **same** item is selected in a `SettingsList` then the `AlertDialog` is not dismissed which does not seem to be the right behaviour. An `AlertDialog` should be dismissed on any confirmation action.

**Note**: I'm not 100% sure that the `padding` I've applied to both `Checkbox` & `Switch` widgets i.e. `padding(end = 8.dp)` is correct as per guidelines, I did not have the chance to look at the docs but they looked similar to the tile icon's start/end padding.