### PR TITLE
Fix incomplete display of subtitle & remove incorrect padding when ic…

### DIFF
--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileScaffold.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileScaffold.kt
@@ -1,17 +1,12 @@
 package com.alorma.compose.settings.ui.internal
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Divider
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
@@ -25,46 +20,61 @@ internal fun SettingsTileScaffold(
   action: (@Composable (Boolean) -> Unit)? = null,
   actionDivider: Boolean = false,
 ) {
-
+  val maxHeight = if (subtitle == null) 72.dp else 88.dp
   ListItem(
-    modifier = Modifier.height(56.dp),
+    modifier = Modifier
+      .height(IntrinsicSize.Min)
+      .heightIn(56.dp, maxHeight),
     headlineText = {
       WrapContentColor(enabled = enabled) {
         title()
       }
     },
-    supportingText = {
-      WrapContentColor(enabled = enabled) {
-        subtitle?.invoke()
+    supportingText = if (subtitle == null) {
+      null
+    } else {
+      {
+        WrapContentColor(enabled = enabled) {
+          subtitle()
+        }
       }
     },
-    leadingContent = {
-      WrapContentColor(enabled = enabled) {
-        icon?.invoke()
+    leadingContent = if (icon == null) {
+      null
+    } else {
+      {
+        WrapContentColor(enabled = enabled) {
+          icon()
+        }
       }
     },
     trailingContent = if (action == null) {
       null
     } else {
       {
-        if (actionDivider) {
-          val color = DividerDefaults.color.copy(
-            alpha = if (enabled) {
-              1f
-            } else {
-              0.6f
-            }
-          )
-          Divider(
-            color = color,
-            modifier = Modifier
-              .padding(vertical = 4.dp)
-              .fillMaxHeight()
-              .width(1.dp),
-          )
+        Row(
+          modifier = Modifier.fillMaxHeight(),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          if (actionDivider) {
+            val color = DividerDefaults.color.copy(
+              alpha = if (enabled) {
+                1f
+              } else {
+                0.6f
+              }
+            )
+            Divider(
+              color = color,
+              modifier = Modifier
+                .padding(vertical = 4.dp)
+                .fillMaxHeight()
+                .width(1.dp),
+            )
+            Spacer(modifier = Modifier.width(2.dp))
+          }
+          action(enabled)
         }
-        Spacer(modifier = Modifier.width(2.dp))
-        action(enabled)
       }
     },
   )


### PR DESCRIPTION
Fix incomplete display of subtitle & remove incorrect padding when icon is null

I find that when the subtitle is too long, it only shows one line and the overflow doesn't show up, which I don't think is the correct representation
And, in the [m3's specification](https://m3.material.io/components/lists/specs), when there is no icon, the padding start should be 16dp and here there is a full 32dp of padding, which is also incorrect