### PR TITLE
Fix Enable/Disable for SettingsSwitch

### DIFF
--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
@@ -62,7 +62,8 @@ fun SettingsSwitch(
           Switch(
             checked = storageValue,
             onCheckedChange = update,
-            Modifier.padding(end = 8.dp)
+            modifier = Modifier.padding(end = 8.dp),
+            enabled = enabled,
           )
         }
       }


### PR DESCRIPTION
Currently, the M2-SettingsSwitch can be enabled/disabled. But this behavior has no relation to the Switch itself. 
This means the switch can be changed although the preference is deactivated. This PR changes the behavior so that the switch will also be enabled/disabled.