### PR TITLE
Fixed the heigh of the ListPreference

### DIFF
--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileScaffold.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileScaffold.kt
@@ -20,11 +20,11 @@ internal fun SettingsTileScaffold(
   action: (@Composable (Boolean) -> Unit)? = null,
   actionDivider: Boolean = false,
 ) {
-  val maxHeight = if (subtitle == null) 72.dp else 88.dp
+  val minHeight = if (subtitle == null) 72.dp else 88.dp
   ListItem(
     modifier = Modifier
       .height(IntrinsicSize.Min)
-      .heightIn(56.dp, maxHeight),
+      .defaultMinSize(minHeight = minHeight),
     headlineText = {
       WrapContentColor(enabled = enabled) {
         title()


### PR DESCRIPTION
I reported the issue [here](https://github.com/alorma/Compose-Settings/issues/117), apparently this only happens in the Material3 version due the SettingsTileScaffold implementation. the max high this view can have is 88.dp I'm setting the min to either 72 or 88dp in case that the subtitle exits.
The possible issue is if the subtitle composable is super Huge this will might looks weird, but this should be the developer  who is implementing this library responsability.
also could be an option to add max heigh around 200.dp
like 
`val maxHeight = if (subtitle == null) 72.dp else 240.dp` but I think this is better.