### PR TITLE
[Improvement] Add custom background color to the settings screen

### DIFF
--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsCheckbox.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsCheckbox.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.internal.enableLiveLiterals
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import com.alorma.compose.settings.storage.base.SettingValueState
@@ -34,6 +35,7 @@ fun SettingsCheckbox(
   subtitle: @Composable (() -> Unit)? = null,
   checkboxColors: CheckboxColors = CheckboxDefaults.colors(),
   onCheckedChange: (Boolean) -> Unit = {},
+  containerColor: Color = MaterialTheme.colorScheme.surface
 ) {
   var storageValue by state
   val update: (Boolean) -> Unit = { boolean ->
@@ -65,6 +67,7 @@ fun SettingsCheckbox(
             colors = checkboxColors
           )
         },
+        containerColor = containerColor
       )
     }
   }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsListDropdown.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.alorma.compose.settings.storage.base.SettingValueState
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
@@ -36,6 +38,7 @@ fun SettingsListDropdown(
   subtitle: (@Composable () -> Unit)? = null,
   onItemSelected: ((Int, String) -> Unit)? = null,
   menuItem: (@Composable (index: Int, text: String) -> Unit)? = null,
+  containerColor: Color = MaterialTheme.colorScheme.surface
 ) {
   if (state.value > items.size) {
     throw IndexOutOfBoundsException("Current value of state for list setting cannot be grater than items size")
@@ -45,7 +48,8 @@ fun SettingsListDropdown(
     var isDropdownExpanded by remember { mutableStateOf(false) }
 
     Row(
-      modifier = modifier.fillMaxWidth()
+      modifier = modifier
+        .fillMaxWidth()
         .clickable(enabled = enabled) { isDropdownExpanded = true },
       verticalAlignment = Alignment.CenterVertically
     ) {
@@ -95,6 +99,7 @@ fun SettingsListDropdown(
             }
           }
         },
+        containerColor = containerColor
       )
     }
   }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsMenuLink.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsMenuLink.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.alorma.compose.settings.ui.internal.SettingsTileScaffold
 
@@ -28,6 +29,7 @@ fun SettingsMenuLink(
   title: @Composable () -> Unit,
   subtitle: (@Composable () -> Unit)? = null,
   action: (@Composable (Boolean) -> Unit)? = null,
+  containerColor: Color = MaterialTheme.colorScheme.surface,
   onClick: () -> Unit,
 ) {
   Surface {
@@ -46,6 +48,7 @@ fun SettingsMenuLink(
         icon = icon,
         action = action,
         actionDivider = true,
+        containerColor = containerColor
       )
     }
   }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSlider.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSlider.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Surface
@@ -12,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.alorma.compose.settings.storage.base.SettingValueState
 import com.alorma.compose.settings.storage.base.getValue
@@ -32,7 +34,8 @@ fun SettingsSlider(
   @IntRange(from = 0) steps: Int = 0,
   onValueChangeFinished: (() -> Unit)? = null,
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-  colors: SliderColors = SliderDefaults.colors()
+  colors: SliderColors = SliderDefaults.colors(),
+  containerColor: Color = MaterialTheme.colorScheme.surface
 ) {
   var settingValue by state
   Surface {
@@ -56,7 +59,8 @@ fun SettingsSlider(
         steps = steps,
         onValueChangeFinished = onValueChangeFinished,
         interactionSource = interactionSource,
-        colors = colors
+        colors = colors,
+        containerColor = containerColor
       )
     }
   }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import com.alorma.compose.settings.storage.base.SettingValueState
@@ -33,6 +34,7 @@ fun SettingsSwitch(
   subtitle: @Composable (() -> Unit)? = null,
   switchColors: SwitchColors = SwitchDefaults.colors(),
   onCheckedChange: (Boolean) -> Unit = {},
+  containerColor: Color = MaterialTheme.colorScheme.surface
 ) {
   var storageValue by state
   val update: (Boolean) -> Unit = { boolean ->
@@ -64,6 +66,7 @@ fun SettingsSwitch(
             colors = switchColors,
           )
         },
+        containerColor = containerColor
       )
     }
   }

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileScaffold.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileScaffold.kt
@@ -5,9 +5,12 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.DividerDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -19,6 +22,7 @@ internal fun SettingsTileScaffold(
   icon: (@Composable () -> Unit)? = null,
   action: (@Composable (Boolean) -> Unit)? = null,
   actionDivider: Boolean = false,
+  containerColor: Color = MaterialTheme.colorScheme.surface
 ) {
   val minHeight = if (subtitle == null) 72.dp else 88.dp
   ListItem(
@@ -77,6 +81,9 @@ internal fun SettingsTileScaffold(
         }
       }
     },
+    colors = ListItemDefaults.colors(
+      containerColor = containerColor
+    )
   )
 }
 

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileSlider.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileSlider.kt
@@ -4,12 +4,14 @@ import androidx.annotation.IntRange
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -24,7 +26,8 @@ internal fun SettingsTileSlider(
   @IntRange(from = 0) steps: Int = 0,
   onValueChangeFinished: (() -> Unit)? = null,
   interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-  colors: SliderColors = SliderDefaults.colors()
+  colors: SliderColors = SliderDefaults.colors(),
+  containerColor: Color = MaterialTheme.colorScheme.surface
 ) {
 
   SettingsTileScaffold(
@@ -52,5 +55,6 @@ internal fun SettingsTileSlider(
       }
     },
     icon = icon,
+    containerColor = containerColor
   )
 }


### PR DESCRIPTION
# Background:
Currently there is an issue for the SettingsTileScaffold, by default display the material surface color, however when the switch is displayed in other screens that does not have this material colors, there is a "Surface shape" background , as an example, if the settings is used in a bottom sheet , the elevation of teh bottom sheet is different so the color also is different.
some components are wrapped by `Surface` component, however this is covered by SettingsTileScaffold.

This PR aim to make this optional, and use different background color. 

I also thinking of removing the `Surface` wrapping like this
```kotlin
Row(
      modifier = modifier
        .fillMaxWidth()
        .toggleable(
          enabled = enabled,
          value = storageValue,
          role = Role.Switch,
          onValueChange = { update(!storageValue) }
        ),
      verticalAlignment = Alignment.CenterVertically,
    )
```
so is possible to set Transparent background. but maybe for now the background should be enough.


|  Before | After   |
|---|---|
|  ![compose_settings_before](https://user-images.githubusercontent.com/1240069/231740063-5461c18e-93c5-410d-a5ed-40f2ace70641.png) | ![compose_settings_after](https://user-images.githubusercontent.com/1240069/231739902-d7dfc025-c384-4671-aee4-997ef24eb971.png) |



