### PR TITLE
Fix checkbox and switch position on long texts on M2

### DIFF
--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsCheckbox.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsCheckbox.kt
@@ -1,7 +1,6 @@
 package com.alorma.compose.settings.ui
 
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
@@ -59,8 +58,7 @@ fun SettingsCheckbox(
     ) {
       WrapContentColor(enabled = enabled) {
         SettingsTileIcon(icon = icon)
-        SettingsTileTexts(title = title, subtitle = subtitle)
-        Spacer(modifier = Modifier.weight(1f))
+        SettingsTileTexts(modifier = Modifier.weight(1f), title = title, subtitle = subtitle)
         SettingsTileAction {
           Checkbox(
             enabled = enabled,

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSwitch.kt
@@ -1,7 +1,6 @@
 package com.alorma.compose.settings.ui
 
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
@@ -59,8 +58,7 @@ fun SettingsSwitch(
     ) {
       WrapContentColor(enabled = enabled) {
         SettingsTileIcon(icon = icon)
-        SettingsTileTexts(title = title, subtitle = subtitle)
-        Spacer(modifier = Modifier.weight(1f))
+        SettingsTileTexts(modifier = Modifier.weight(1f), title = title, subtitle = subtitle)
         SettingsTileAction {
           Switch(
             checked = storageValue,

--- a/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileTexts.kt
+++ b/compose-settings-ui/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileTexts.kt
@@ -16,7 +16,7 @@ internal fun RowScope.SettingsTileTexts(
     subtitle: @Composable (() -> Unit)?,
 ) {
     Column(
-        modifier = Modifier,
+        modifier = modifier,
         verticalArrangement = Arrangement.Center,
     ) {
         SettingsTileTitle(title)


### PR DESCRIPTION
Fix positions of switches and on long text on M2. Removed the Spacer and moved the weight to the SettingsTileTexts element. This ensures that the icon and switch/checkbox is measured first. It'll still fill the remaining space. Also fixed an unused Modifier on SettingsTileTexts.

Swiches before:
<img src="https://github.com/alorma/Compose-Settings/assets/1102306/c369f4c3-da9f-4129-9369-26108877dedd" height="250">
Switches after:
<img src="https://github.com/alorma/Compose-Settings/assets/1102306/ce2cf131-ce0e-4f54-abcd-44e0a32bb499" height="250">

Checkboxes before:
<img src="https://github.com/alorma/Compose-Settings/assets/1102306/55551108-82e8-4790-a69a-58f3afcbc504" height="250">
Checkboxes after:
<img src="https://github.com/alorma/Compose-Settings/assets/1102306/34cacc54-50d8-4785-a43e-c401e8114fa4" height="250">

