### PR TITLE
SettingsSlider supports generic Number states

### DIFF
--- a/app_m3/src/main/java/com/alorma/compose/settings/example/ui/screens/SlidersScreen.kt
+++ b/app_m3/src/main/java/com/alorma/compose/settings/example/ui/screens/SlidersScreen.kt
@@ -18,13 +18,14 @@ import androidx.navigation.NavHostController
 import com.alorma.compose.settings.example.demo.AppScaffold
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
 import com.alorma.compose.settings.storage.datastore.rememberPreferenceDataStoreFloatSettingState
+import com.alorma.compose.settings.storage.datastore.rememberPreferenceDataStoreIntSettingState
 import com.alorma.compose.settings.ui.SettingsSlider
 
 @Composable
 fun SlidersScreen(navController: NavHostController) {
   val settingBrightness = rememberPreferenceDataStoreFloatSettingState(key = "brightness", defaultValue = 0f)
   val settingVolume = rememberPreferenceDataStoreFloatSettingState(key = "volume", defaultValue = 0f)
-  val settingColors = rememberPreferenceDataStoreFloatSettingState(key = "colors", defaultValue = 0f)
+  val settingColors = rememberPreferenceDataStoreIntSettingState(key = "colors", defaultValue = 0)
 
   val enabledState = rememberBooleanSettingState(true)
 

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSlider.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/SettingsSlider.kt
@@ -20,12 +20,12 @@ import com.alorma.compose.settings.storage.base.setValue
 import com.alorma.compose.settings.ui.internal.SettingsTileSlider
 
 @Composable
-fun SettingsSlider(
+fun <T : Number> SettingsSlider(
   modifier: Modifier = Modifier,
-  state: SettingValueState<Float> = rememberFloatSettingState(),
+  state: SettingValueState<T>,
   icon: @Composable (() -> Unit)? = null,
   title: @Composable () -> Unit,
-  onValueChange: (Float) -> Unit = {},
+  onValueChange: (T) -> Unit = {},
   sliderModifier: Modifier = Modifier,
   enabled: Boolean = true,
   valueRange: ClosedFloatingPointRange<Float> = 0f..1f,

--- a/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileSlider.kt
+++ b/compose-settings-ui-m3/src/main/kotlin/com/alorma/compose/settings/ui/internal/SettingsTileSlider.kt
@@ -13,10 +13,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-internal fun SettingsTileSlider(
+internal fun <T : Number> SettingsTileSlider(
   title: @Composable () -> Unit,
-  value: Float,
-  onValueChange: (Float) -> Unit,
+  value: T,
+  onValueChange: (T) -> Unit,
   modifier: Modifier = Modifier,
   icon: (@Composable () -> Unit)? = null,
   enabled: Boolean = true,
@@ -37,8 +37,11 @@ internal fun SettingsTileSlider(
           .then(modifier)
       ) {
         Slider(
-          value = value,
-          onValueChange = onValueChange,
+          value = value.toFloat(),
+          onValueChange = { value ->
+            @Suppress("UNCHECKED_CAST")
+            onValueChange(value as T)
+          },
           modifier = Modifier
             .padding(end = 16.dp)
             .then(modifier),


### PR DESCRIPTION
Allows to use e.g. `Int` state inside of `SettingsSlider`.