### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,33 +6,18 @@ on:
     types: [ released ]
 
 jobs:
-  build:
-    name: Build - Publish
+  publish:
     runs-on: macos-latest
+
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
 
-        # Builds the debug artifacts of the library
-      - name: Build - Publish
-        run: ./gradlew build
-
-  publish:
-    needs: [ build ]
-    runs-on: macos-latest
-    steps:
       # Runs upload, and then closes & releases the repository
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
Jobs inside a workflow run in parallel, so the publishing one never got any build output or even code. With this change there's just one `publish` job that checks out, builds and publishes. (The right build gets triggered automatically as a dependency from the publishing command).